### PR TITLE
feat: Add the ability to display identicons next to password fields

### DIFF
--- a/src/css/option.less
+++ b/src/css/option.less
@@ -242,7 +242,7 @@ body {
   div.card2 {
     position: relative;
     width: 98%;
-    height: 260px;
+    height: 320px;
     float: left;
     display: block;
     border-radius: 8px;

--- a/src/css/popup.less
+++ b/src/css/popup.less
@@ -107,14 +107,24 @@ p.left {
   text-align: left;
 }
 
-#master_input input.good {
-  background: #effcef !important;
-  outline: none!important;
+#master_input {
+  position: relative;
+
+  input.good {
+    background: #effcef !important;
+    outline: none!important;
+  }
+
+  input.bad {
+    background: #ffe8ea !important;
+    outline: none!important;
+  }
 }
 
-#master_input input.bad {
-  background: #ffe8ea !important;
-  outline: none!important;
+#password_feedback {
+  position: absolute;
+  right: 20px;
+  top: 35px;
 }
 
 input[type=password],

--- a/src/css/scp.less
+++ b/src/css/scp.less
@@ -113,6 +113,17 @@
         background: #ffe8ea !important;
       }
     }
+
+    canvas + input {
+      width: 115px !important;
+    }
+
+    canvas {
+      position: absolute;
+      top: 15px;
+      right: 4px;
+    }
+
   }
 
   &.corner {
@@ -128,4 +139,5 @@
       img {}
     }
   }
+
 }

--- a/src/js/identicon5.js
+++ b/src/js/identicon5.js
@@ -1,0 +1,253 @@
+/*
+
+  Plugin: Identicon5 v1.0.0
+  Author: http://FrancisShanahan.com
+  Description: Draws identicons using HTML5 Canvas.
+
+  Attribution: Based off the PHP implementation of Don Park's original identicon
+  code for visual representation of MD5 hash values.
+
+  Reference: http://sourceforge.net/projects/identicons/
+
+*/
+
+/*
+
+  Modified for SuperGenPass:
+  1. Do not fallback to Gravatar images (prevents password hashes from appearing in foreign server log).
+  2. Require a canvas element to passed as a parameter.
+  3. Require a hash to be passed as a parameter.
+  4. Add support for high-dpi identicons.
+  5. Remove dependency on jQuery.
+  6. Remove test function.
+  7. Export function for require.
+
+*/
+
+/* Further modification for the Chrome extension:
+  1. Removed export, made module into a single global function
+*/
+
+'use strict';
+
+var identicon5 = function (canvas, hash, size) {
+
+  /* fills a polygon based on a path */
+  var fillPoly = function (ctx, path) {
+    if (path.length >= 2) {
+      ctx.beginPath();
+      ctx.moveTo(path[0], path[1]);
+      for (var i = 2; i < path.length; i++) {
+        ctx.lineTo(path[i], path[i + 1]);
+        i++;
+      }
+      ctx.fill();
+    }
+  };
+
+  /* generate sprite for corners and sides */
+  var getsprite = function (shape, size) {
+
+    switch (shape) {
+    case 0: // triangle
+      shape = [0.5, 1, 1, 0, 1, 1];
+      break;
+    case 1: // parallelogram
+      shape = [0.5, 0, 1, 0, 0.5, 1, 0, 1];
+      break;
+    case 2: // mouse ears
+      shape = [0.5, 0, 1, 0, 1, 1, 0.5, 1, 1, 0.5];
+      break;
+    case 3: // ribbon
+      shape = [0, 0.5, 0.5, 0, 1, 0.5, 0.5, 1, 0.5, 0.5];
+      break;
+    case 4: // sails
+      shape = [0, 0.5, 1, 0, 1, 1, 0, 1, 1, 0.5];
+      break;
+    case 5: // fins
+      shape = [1, 0, 1, 1, 0.5, 1, 1, 0.5, 0.5, 0.5];
+      break;
+    case 6: // beak
+      shape = [0, 0, 1, 0, 1, 0.5, 0, 0, 0.5, 1, 0, 1];
+      break;
+    case 7: // chevron
+      shape = [0, 0, 0.5, 0, 1, 0.5, 0.5, 1, 0, 1, 0.5, 0.5];
+      break;
+    case 8: // fish
+      shape = [0.5, 0, 0.5, 0.5, 1, 0.5, 1, 1, 0.5, 1, 0.5, 0.5, 0, 0.5];
+      break;
+    case 9: // kite
+      shape = [0, 0, 1, 0, 0.5, 0.5, 1, 0.5, 0.5, 1, 0.5, 0.5, 0, 1];
+      break;
+    case 10: // trough
+      shape = [0, 0.5, 0.5, 1, 1, 0.5, 0.5, 0, 1, 0, 1, 1, 0, 1];
+      break;
+    case 11: // rays
+      shape = [0.5, 0, 1, 0, 1, 1, 0.5, 1, 1, 0.75, 0.5, 0.5, 1, 0.25];
+      break;
+    case 12: // double rhombus
+      shape = [0, 0.5, 0.5, 0, 0.5, 0.5, 1, 0, 1, 0.5, 0.5, 1, 0.5, 0.5, 0, 1];
+      break;
+    case 13: // crown
+      shape = [0, 0, 1, 0, 1, 1, 0, 1, 1, 0.5, 0.5, 0.25, 0.5, 0.75, 0, 0.5, 0.5, 0.25];
+      break;
+    case 14: // radioactive
+      shape = [0, 0.5, 0.5, 0.5, 0.5, 0, 1, 0, 0.5, 0.5, 1, 0.5, 0.5, 1, 0.5, 0.5, 0, 1];
+      break;
+    default: // tiles
+      shape = [0, 0, 1, 0, 0.5, 0.5, 0.5, 0, 0, 0.5, 1, 0.5, 0.5, 1, 0.5, 0.5, 0, 1];
+      break;
+    }
+
+    /* scale up */
+    for (var i = 0; i < shape.length; i++) {
+      shape[i] = shape[i] * size;
+    }
+
+    return shape;
+
+  };
+
+  /* Draw a polygon at location x,y and rotated by angle */
+  /* assumes polys are square */
+  var drawRotatedPolygon = function (ctx, sprite, x, y, shapeangle, angle, size) {
+
+    var halfSize = size / 2;
+    ctx.save();
+
+    ctx.translate(x, y);
+    ctx.rotate(angle * Math.PI / 180);
+    ctx.save();
+    ctx.translate(halfSize, halfSize);
+    var tmpSprite = [];
+    for (var p = 0; p < sprite.length; p++) {
+      tmpSprite[p] = sprite[p] - halfSize;
+    }
+    ctx.rotate(shapeangle);
+    fillPoly(ctx, tmpSprite);
+
+    ctx.restore();
+    ctx.restore();
+
+  };
+
+  /* generate sprite for center block */
+  var getcenter = function (shape, size) {
+
+    switch (shape) {
+    case 0: // empty
+      shape = [];
+      break;
+    case 1: // fill
+      shape = [0, 0, 1, 0, 1, 1, 0, 1];
+      break;
+    case 2: // diamond
+      shape = [0.5, 0, 1, 0.5, 0.5, 1, 0, 0.5];
+      break;
+    case 3: // reverse diamond
+      shape = [0, 0, 1, 0, 1, 1, 0, 1, 0, 0.5, 0.5, 1, 1, 0.5, 0.5, 0, 0, 0.5];
+      break;
+    case 4: // cross
+      shape = [0.25, 0, 0.75, 0, 0.5, 0.5, 1, 0.25, 1, 0.75, 0.5, 0.5, 0.75, 1, 0.25, 1, 0.5, 0.5, 0, 0.75, 0, 0.25, 0.5, 0.5];
+      break;
+    case 5: // morning star
+      shape = [0, 0, 0.5, 0.25, 1, 0, 0.75, 0.5, 1, 1, 0.5, 0.75, 0, 1, 0.25, 0.5];
+      break;
+    case 6: // small square
+      shape = [0.33, 0.33, 0.67, 0.33, 0.67, 0.67, 0.33, 0.67];
+      break;
+    case 7: // checkerboard
+      shape = [0, 0, 0.33, 0, 0.33, 0.33, 0.66, 0.33, 0.67, 0, 1, 0, 1, 0.33, 0.67, 0.33, 0.67, 0.67, 1, 0.67, 1, 1, 0.67, 1, 0.67, 0.67, 0.33, 0.67, 0.33, 1, 0, 1, 0, 0.67, 0.33, 0.67, 0.33, 0.33, 0, 0.33];
+      break;
+    default: // tiles
+      shape = [0, 0, 1, 0, 0.5, 0.5, 0.5, 0, 0, 0.5, 1, 0.5, 0.5, 1, 0.5, 0.5, 0, 1];
+      break;
+    }
+
+    /* apply ratios */
+    for (var i = 0; i < shape.length; i++) {
+      shape[i] = shape[i] * size;
+    }
+
+    return shape;
+
+  };
+
+  // main drawing function.
+  // Draws a identicon, based off an MD5 hash value of size "width"
+  // (identicons are always square)
+  var draw = function (ctx, hash, width) {
+
+    var csh = parseInt(hash.substr(0, 1), 16); // corner sprite shape
+    var ssh = parseInt(hash.substr(1, 1), 16); // side sprite shape
+    var xsh = parseInt(hash.substr(2, 1), 16) & 7; // center sprite shape
+
+    var halfPi = Math.PI/2;
+    var cro = halfPi * (parseInt(hash.substr(3, 1), 16) & 3); // corner sprite rotation
+    var sro = halfPi * (parseInt(hash.substr(4, 1), 16) & 3); // side sprite rotation
+    var xbg = parseInt(hash.substr(5, 1), 16) % 2; // center sprite background
+
+    /* corner sprite foreground color */
+    var cfr = parseInt(hash.substr(6, 2), 16);
+    var cfg = parseInt(hash.substr(8, 2), 16);
+    var cfb = parseInt(hash.substr(10, 2), 16);
+
+    /* side sprite foreground color */
+    var sfr = parseInt(hash.substr(12, 2), 16);
+    var sfg = parseInt(hash.substr(14, 2), 16);
+    var sfb = parseInt(hash.substr(16, 2), 16);
+
+    /* size of each sprite */
+    var size = width / 3;
+    var totalsize = width;
+
+    /* start with blank 3x3 identicon */
+
+    /* generate corner sprites */
+    var corner = getsprite(csh, size);
+    ctx.fillStyle = "rgb(" + cfr + "," + cfg + "," + cfb + ")";
+    drawRotatedPolygon(ctx, corner, 0, 0, cro, 0, size);
+    drawRotatedPolygon(ctx, corner, totalsize, 0, cro, 90, size);
+    drawRotatedPolygon(ctx, corner, totalsize, totalsize, cro, 180, size);
+    drawRotatedPolygon(ctx, corner, 0, totalsize, cro, 270, size);
+
+    /* draw sides */
+    var side = getsprite(ssh, size);
+    ctx.fillStyle = "rgb(" + sfr + "," + sfg + "," + sfb + ")";
+    drawRotatedPolygon(ctx, side, 0, size, sro, 0, size);
+    drawRotatedPolygon(ctx, side, 2 * size, 0, sro, 90, size);
+    drawRotatedPolygon(ctx, side, 3 * size, 2 * size, sro, 180, size);
+    drawRotatedPolygon(ctx, side, size, 3 * size, sro, 270, size);
+
+    var center = getcenter(xsh, size);
+
+    /* make sure there's enough contrast before we use background color of side sprite */
+    if (xbg > 0 && (Math.abs(cfr - sfr) > 127 || Math.abs(cfg - sfg) > 127 || Math.abs(cfb - sfb) > 127)) {
+      ctx.fillStyle = "rgb(" + sfr + "," + sfg + "," + sfb + ")";
+    } else {
+      ctx.fillStyle = "rgb(" + cfr + "," + cfg + "," + cfb + ")";
+    }
+
+    drawRotatedPolygon(ctx, center, size, size, 0, 0, size);
+
+  };
+
+  if (hash && canvas && canvas.getContext) {
+
+    // canvas is supported
+    var ctx = canvas.getContext("2d");
+
+    // support high-dpi
+    if(window.devicePixelRatio && window.devicePixelRatio == 2) {
+      canvas.width = canvas.height = size * 2;
+      ctx.scale(2, 2);
+    } else {
+      canvas.width = canvas.height = size;
+    }
+
+    draw(ctx, hash, size);
+
+  }
+
+};
+

--- a/src/js/option.js
+++ b/src/js/option.js
@@ -213,6 +213,16 @@ $(document).ready(function() {
     localStorage['options'] = JSON.stringify(options);
   });
 
+  $('#include_identicon').click(function() {
+    var options = JSON.parse(localStorage['options'] || '{}');
+    if ($(this).is(':checked')) {
+      options.include_identicon = true;
+    } else {
+      options.include_identicon = false;
+    }
+    localStorage['options'] = JSON.stringify(options);
+  });
+
   $('#key_key').keyup(function(e) {
     $('#key_key').val(String.fromCharCode(e.which));
     var options = JSON.parse(localStorage['options'] || '{}');
@@ -229,5 +239,7 @@ $(document).ready(function() {
   options.special_characters ?
     $('#special_characters').attr('checked', 'checked') :
     $('#special_characters').removeAttr('checked', 'checked');
-
+  options.include_identicon ?
+    $('#include_identicon').attr('checked', 'checked') :
+    $('#include_identicon').removeAttr('checked', 'checked');
 });

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -2,6 +2,20 @@ var passid = false,
   sendPass = false,
   passes = JSON.parse(localStorage['passwords'] || '[]'),
   options = JSON.parse(localStorage['options'] || '{}');
+
+function generateIcon() {
+  var seed = $('#password').val();
+  if (seed) {
+    $('#password_feedback').show();
+    for (var i = 0; i <= 4; i = i + 1) {
+      seed = hex_md5(seed).toString();
+    }
+    identicon5($('#password_feedback').get(0), seed, 16);
+  } else {
+    $('#password_feedback').hide();
+  }
+}
+
 function selectText(element) {
   var text = document.getElementById(element);
   if (document.body.createTextRange) {
@@ -172,6 +186,10 @@ $(document).ready(function() {
   });
 
   $('#password').keyup(function(e) {
+    if (options.include_identicon) {
+      generateIcon();
+    }
+
     this.value.length > 0 ?
       $('#regen').removeAttr('disabled') :
       $('#regen').attr('disabled', 'disabled');

--- a/src/js/superchromepass.js
+++ b/src/js/superchromepass.js
@@ -181,6 +181,9 @@ $(document).ready(function() {
   }
 
   scpinput = function(response, self, tld, id) {
+    if (options.include_identicon) {
+      $(self).append($('<canvas width="16" height="16"></canvas>'));
+    }
     $(self).append(
       $('<input/>', {
         type: 'text', //chrome autocomplete function forbid trick
@@ -189,6 +192,20 @@ $(document).ready(function() {
         autocomplete: 'off'
       }).keyup(function(e) {
         this.type = 'password'; //chrome autocomplete function forbid trick
+        var canvas = $(this).prev('canvas');
+        // Update identicon if it exists
+        if (canvas) {
+          var seed = $(this).val();
+          if (seed) {
+            canvas.show();
+            for (var i = 0; i <= 4; i = i + 1) {
+              seed = hex_md5(seed).toString();
+            }
+            identicon5(canvas.get(0), seed, 16);
+          } else {
+            canvas.hide();
+          }
+        }
         if (response.hash) {
           if (b64_md5($(this).val()) == response.pass) {
             $(this).addClass('good').removeClass('bad');

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
   },
   "content_scripts": [{
     "css": ["css/scp.css"],
-    "js": ["js/jquery.js", "js/superchromepass.js", "js/supergenpass.js"],
+    "js": ["js/jquery.js", "js/superchromepass.js", "js/supergenpass.js", "js/identicon5.js"],
     "matches": ["http://*/*", "https://*/*"]
   }],
   "description": "Generate secure, per-domain password based on an original master password, with the click of a button",

--- a/src/scp_options.html
+++ b/src/scp_options.html
@@ -75,6 +75,9 @@
 <p></p>
         <input type="checkbox" id="special_characters" checked="">
         <label for="special_characters" id="option_special_characters_label">Convert last 2 characters to special characters, include ( ~!@#%^&*()_+=-[]\|}{ )</label>
+<p></p>
+        <input type="checkbox" id="include_identicon" checked="">
+        <label for="include_identicon" id="option_include_identicon_label">Add identicon graphic next to the master password fields when using the extension without profiles</label>
 
           <h3 id="option_shortcut_key">Shortcut Key</h3>
 

--- a/src/scp_popup.html
+++ b/src/scp_popup.html
@@ -8,6 +8,7 @@
   <script type="text/javascript" src="js/password.class.js"></script>
   <script type="text/javascript" src="js/supergenpass.js"></script>
   <script type="text/javascript" src="js/popup.js"></script>
+  <script type="text/javascript" src="js/identicon5.js"></script>
 </head>
 
 <body>
@@ -37,6 +38,7 @@
     <div id="master_input" style="display: none">
       <label class="main" id="dscr" for="Passwd">popup_master_password</label>
       <input id="password" type="password" autofocus="autofocus">
+      <canvas id="password_feedback" width="16" height="16"></canvas>
     </div>
 
     <div id="generated" style="display: none">


### PR DESCRIPTION
Identicons can help the user make sure they are typing their password
correctly without making the password itself visible. This change adds
the exact same identicon algorithm the original SuperGenPass bookmarklet
had, which means all generated icons should be the same as well.

Displaying identicons can be toggled on the options page (they are
disabled by default).

I did not include the release files in this commit, but can amend them if required.